### PR TITLE
implement batch remove items api 

### DIFF
--- a/lib/constructorio/client.rb
+++ b/lib/constructorio/client.rb
@@ -53,6 +53,10 @@ module ConstructorIO
       call_api("batch_items", "put", params, {force: 1})
     end
 
+    def remove_batch(params)
+      call_api("batch_items","delete",params)
+    end
+
     private
 
     def call_api(path, method, params = {}, additional_query_params = {})

--- a/lib/constructorio/version.rb
+++ b/lib/constructorio/version.rb
@@ -1,3 +1,3 @@
 module ConstructorIO
-  VERSION = "2.0.10"
+  VERSION = "2.0.11"
 end

--- a/test/constructorio_test.rb
+++ b/test/constructorio_test.rb
@@ -187,4 +187,24 @@ class ConstructorIOTest < MiniTest::Test
       }
     )
   end
+
+  def test_remove_batch_sends_request
+    c = ConstructorIO::Client.new
+    c.expects(:send_request).with(
+      "batch_items",
+      "delete",
+      instance_of(Faraday::Connection),
+      { autocomplete_section: "Products", items: [ { item_name: "item" } ] },
+      "example_autocomplete_key"
+    )
+    c.remove_batch(
+      {
+        autocomplete_section: "Products",
+        items: [ { item_name: "item" } ] 
+      }
+    )
+  end
+
+
+
 end


### PR DESCRIPTION
This pull request adds the `batch remove` item api. 

User can do 

    response = constructorio.remove_batch(
      {
        items: [
          { item_name: "power drill" },
          { item_name: "hammer" }
       ],
       autocomplete_section: "Search Suggestions"
     }
    );

The `specs` aren't tested but i guess it will work. 