### PR TITLE
[TOOLS-735] Update Faraday version to resolve dependencies

### DIFF
--- a/constructorio.gemspec
+++ b/constructorio.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'faraday', '~> 0.9', '>= 0.9.0'
+  spec.add_dependency 'faraday', '~> 1.0', '>= 1.0'
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency 'pry', '~> 0.10', '>= 0.10.1'

--- a/lib/constructorio/version.rb
+++ b/lib/constructorio/version.rb
@@ -1,3 +1,3 @@
 module ConstructorIO
-  VERSION = "2.0.12"
+  VERSION = "2.0.13"
 end


### PR DESCRIPTION
Update Faraday version to update dependencies as new sentry SDK depends on a newer version of Faraday